### PR TITLE
Updated get_group and get_group_from_info to return a Click Group object

### DIFF
--- a/typer/main.py
+++ b/typer/main.py
@@ -213,7 +213,7 @@ class Typer:
         return get_command(self)()
 
 
-def get_group(typer_instance: Typer) -> click.Command:
+def get_group(typer_instance: Typer) -> click.Group:
     group = get_group_from_info(TyperInfo(typer_instance))
     return group
 
@@ -228,11 +228,11 @@ def get_command(typer_instance: Typer) -> click.Command:
         or len(typer_instance.registered_commands) > 1
     ):
         # Create a Group
-        click_command = get_group(typer_instance)
+        click_group = get_group(typer_instance)
         if typer_instance._add_completion:
-            click_command.params.append(click_install_param)
-            click_command.params.append(click_show_param)
-        return click_command
+            click_group.params.append(click_install_param)
+            click_group.params.append(click_show_param)
+        return click_group
     elif len(typer_instance.registered_commands) == 1:
         # Create a single Command
         click_command = get_command_from_info(typer_instance.registered_commands[0])
@@ -339,7 +339,7 @@ def solve_typer_info_defaults(typer_info: TyperInfo) -> TyperInfo:
     return TyperInfo(**values)
 
 
-def get_group_from_info(group_info: TyperInfo) -> click.Command:
+def get_group_from_info(group_info: TyperInfo) -> click.Group:
     assert (
         group_info.typer_instance
     ), "A Typer instance is needed to generate a Click Group"
@@ -356,7 +356,7 @@ def get_group_from_info(group_info: TyperInfo) -> click.Command:
         convertors,
         context_param_name,
     ) = get_params_convertors_ctx_param_name_from_function(solved_info.callback)
-    cls = solved_info.cls or click.Group
+    cls = click.Group
     group = cls(  # type: ignore
         name=solved_info.name or "",
         commands=commands,


### PR DESCRIPTION
This PR seeks to solve #96 [[BUG] typer.main.get_group should return a click.Group](https://github.com/tiangolo/typer/issues/96) by having `typer.main.get_group` and `typer.main.get_group_from_info` return a `click.Group` instead of a `click.Command`. There may be some issues with this solution - I'll add some comments to the changes using the review tools here.

I tested the code with this script using Typer:
```
import typer

app = typer.Typer()


@app.callback()
def callback():
    """ My partially-upgraded-to-Typer app """

# insert some fancy new Typer commands here


click_group = typer.main.get_group(app)


@click_group.command()
def some_old_click_function():
      """ I need to rewrite this somday """
```


All tests pass locally with 100% coverage. Running mypy on this script with `mypy main.py` returns

> Success: no issues found in 1 source file

Once again, this PR is just looking for initial feedback (criticism on code, styling, logic is especially appreciated).

Does Typer have a standard template for PR? Also, we may want to add `codecov-io` to this repository if it's possible to check for code coverage. I'm also curious as to why the initial tests didn't catch the bug - maybe we could write an additional test with something similar to the script above?